### PR TITLE
Fix text overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@reach/portal": "^0.10.3",
     "@reduxjs/toolkit": "^1.3.5",
     "@sparkpointio/sparkswap-sdk": "0.0.2",
-    "@sparkpointio/sparkswap-uikit": "0.0.13",
+    "@sparkpointio/sparkswap-uikit": "0.0.15",
     "@types/lodash.flatmap": "^4.5.6",
     "@types/multicodec": "^1.0.0",
     "@types/node": "^14.14.16",

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react'
+import DetectableOverflow from 'react-detectable-overflow'
 import { BigNumber } from '@ethersproject/bignumber'
 import { TransactionResponse } from '@ethersproject/providers'
 import { Currency, currencyEquals, ETHER, TokenAmount, WETH } from '@sparkpointio/sparkswap-sdk'
@@ -77,7 +78,10 @@ export default function AddLiquidity({
   // modal and loading
   const [showConfirm, setShowConfirm] = useState<boolean>(false)
   const [attemptingTxn, setAttemptingTxn] = useState<boolean>(false) // clicked confirm
-
+  
+  // check for overflow
+  const [isOverflow, updateIsOverflow] = useState<boolean>(false);
+  
   // txn values
   const [deadline] = useUserDeadline() // custom from users settings
   const [allowedSlippage] = useUserSlippageTolerance() // custom from users
@@ -198,9 +202,10 @@ export default function AddLiquidity({
       <AutoColumn gap="20px">
         <LightCard mt="20px" borderRadius="20px">
           <RowFlat>
-            <UIKitText fontSize="48px" mr="8px">
+            <UIKitText fontSize="1.5em" mr="8px">
               {`${currencies[Field.CURRENCY_A]?.symbol}/${currencies[Field.CURRENCY_B]?.symbol}`}
             </UIKitText>
+  
             <DoubleCurrencyLogo
               currency0={currencies[Field.CURRENCY_A]}
               currency1={currencies[Field.CURRENCY_B]}
@@ -212,7 +217,7 @@ export default function AddLiquidity({
     ) : (
       <AutoColumn gap="20px">
         <RowFlat style={{ marginTop: '20px' }}>
-          <UIKitText fontSize="48px" mr="8px">
+          <UIKitText fontSize='1.5em' mr="8px">
             {liquidityMinted?.toSignificant(6)}
           </UIKitText>
           <DoubleCurrencyLogo

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useState } from 'react'
-import DetectableOverflow from 'react-detectable-overflow'
 import { BigNumber } from '@ethersproject/bignumber'
 import { TransactionResponse } from '@ethersproject/providers'
 import { Currency, currencyEquals, ETHER, TokenAmount, WETH } from '@sparkpointio/sparkswap-sdk'
@@ -202,7 +201,7 @@ export default function AddLiquidity({
       <AutoColumn gap="20px">
         <LightCard mt="20px" borderRadius="20px">
           <RowFlat>
-            <UIKitText fontSize="1.5em" mr="8px">
+            <UIKitText fontSize="1.2em" mr="8px">
               {`${currencies[Field.CURRENCY_A]?.symbol}/${currencies[Field.CURRENCY_B]?.symbol}`}
             </UIKitText>
   
@@ -217,7 +216,7 @@ export default function AddLiquidity({
     ) : (
       <AutoColumn gap="20px">
         <RowFlat style={{ marginTop: '20px' }}>
-          <UIKitText fontSize='1.5em' mr="8px">
+          <UIKitText fontSize='1.2em' mr="8px">
             {liquidityMinted?.toSignificant(6)}
           </UIKitText>
           <DoubleCurrencyLogo

--- a/yarn.lock
+++ b/yarn.lock
@@ -2356,10 +2356,10 @@
     tiny-warning "^1.0.3"
     toformat "^2.0.0"
 
-"@sparkpointio/sparkswap-uikit@0.0.13":
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/@sparkpointio/sparkswap-uikit/-/sparkswap-uikit-0.0.13.tgz#7c7ee87390821817e148b511a1fc637be4c4fa80"
-  integrity sha512-7EpQVc6fIjUfq8F2omjnJHT0eZ/UFVkEr5GZ9rkS80AynMptutJ1/v0r5OP+4NUTnA/GM0HpH8kQSFUsAKmjQw==
+"@sparkpointio/sparkswap-uikit@0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@sparkpointio/sparkswap-uikit/-/sparkswap-uikit-0.0.15.tgz#617d68be4e9e8799b22b94aa6821668e2310f3b7"
+  integrity sha512-Cu7OC6oCrntj5PPl6k6tgXqdTjduR06ylfU5bIYOiGuJ8YJ2CbJ52zjRJcqPA7k0T/YdDCpRwZlKkoOaRwsY8Q==
   dependencies:
     "@types/lodash" "^4.14.162"
     "@types/styled-system" "^5.1.10"


### PR DESCRIPTION
Update font size for the add liquidity modal to avoid overflowing content
![image](https://user-images.githubusercontent.com/43143132/113839302-2713f100-97c2-11eb-8d8a-bfe2b6e3c618.png)


tried a bunch of react lib/npm package and nothing seems to work according to my liking.

example is to have an ellipses ( if its overflowing ) and hover to view the value with a tooltip. 
or add a button to see the full  value

But it's an additional for the users so I didn't implement it. 